### PR TITLE
<perf>(api): build v2 sticker/pack models

### DIFF
--- a/models/StickerDefinition.js
+++ b/models/StickerDefinition.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+const slugify = require('slugify');
+
+const StickerDefinitionSchema = new mongoose.Schema({
+    name: { type: String, required: true },
+    packId: { type: mongoose.Schema.Types.ObjectId, ref: 'StickerPack', required: false },
+    slug: { type: String, unique: true },
+    imageUrl: { type: String, required: true },
+    rarity: { type: String, enum: ['Common', 'Rare', 'Epic', 'Legendary'], default: 'Common' },
+    tags: [String],
+    metadata: {
+        artist: String,
+        series: String
+    },
+    isActive: { type: Boolean, default: true },
+    version: { type: String, default: '1.0' },
+});
+
+StickerDefinitionSchema.pre('save', function () {
+    this.slug = slugify(this.name, { lower: true });
+});
+
+module.exports = mongoose.models.StickerDefinition || mongoose.model('StickerDefinition', StickerDefinitionSchema);

--- a/models/StickerPack.js
+++ b/models/StickerPack.js
@@ -1,0 +1,22 @@
+// sticker catalog will consist of sticker packs and individual sticker definitions
+const mongoose = require('mongoose');
+const slugify = require('slugify');
+
+const StickerPackSchema = new mongoose.Schema({
+    name: { type: String, required: true },
+    description: { type: String, required: false },
+    slug: { type: String, unique: true },
+    packType: { type: String, enum: ['Basic', 'Premium', 'Event'] },
+    theme: { type: String, enum: ['Holiday', 'Achievement', 'Mood'] },
+    stickers: [{ type: mongoose.Schema.Types.ObjectId, ref: 'StickerDefinition' }],
+    price: { type: Number, default: 0 },
+    isActive: { type: Boolean, default: true },
+    sortOrder: { type: Number, default: 0 },
+    coverStickerId: { type: mongoose.Schema.Types.ObjectId, ref: 'StickerDefinition' }
+});
+
+StickerPackSchema.pre('save', function () {
+    this.slug = slugify(this.name, { lower: true });
+});
+
+module.exports = mongoose.models.StickerPack|| mongoose.model('StickerPack', StickerPackSchema);

--- a/scripts/stickerMigration.js
+++ b/scripts/stickerMigration.js
@@ -1,0 +1,131 @@
+/*
+
+    V1 approach to stickers:
+           assets are processed and uploaded to media.stickerboards.app, pushed by CDN
+           User stickers exist in StickerboardSchema.stickers[] by id number, which is hardcoded
+            to correspond to an asset filename.
+           Cheers stickers exist in UserSchema.cheers[] by id number, which is hardcoded to
+            correspond to an asset filename.
+    V2 approach to stickers:
+           Individual sticker entries are defined in the collection StickerDefinition
+            This includes a url to the asset file, versioning, if they are associated to a Pack, 
+                and metadata such as artist and series.
+           Sets of stickers are called Sticker Packs and are in the collection StickerPack
+            Packs ref to individual StickerDefinition entries by id number
+           Stickers and packs available to a user will be listed in the UserSchema 
+           Stickers that have been applied to a board will be listed in the StickerboardSchema
+ 
+    This script will migrate current stickers and assets from the V1 approach to the V2 approach.
+    
+ */
+
+
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const StickerDefinition = require('../models/StickerDefinition');
+const StickerPack = require('../models/StickerPack');
+dotenv.config({ path: '../config/config.env' });
+
+const ASSETS_BASE_URL = 'https://media.stickerboards.app/assets';
+
+const V1_STICKERS = [
+    { id: 0, name: 'Sticker 0' },
+    { id: 1, name: 'Sticker 1' },
+    { id: 2, name: 'Sticker 2' },
+    { id: 3, name: 'Sticker 3' },
+    { id: 4, name: 'Sticker 4' },
+    { id: 5, name: 'Sticker 5' },
+    { id: 6, name: 'Sticker 6' },
+    { id: 7, name: 'Sticker 7' },
+    { id: 8, name: 'Sticker 8' },
+    { id: 9, name: 'Sticker 9' }
+];
+
+const V1_CHEERS = [
+    { id: 0, name: 'Cheers 0' },
+    { id: 1, name: 'Cheers 1' },
+    { id: 2, name: 'Cheers 2' },
+    { id: 3, name: 'Cheers 3' },
+    { id: 4, name: 'Cheers 4' }
+];
+
+const migrate = async () => {
+    try {
+        await mongoose.connect(process.env.MONGO_URI);
+
+        console.log('Connected to database...');
+
+        const stickerMap = {};
+        const cheersMap = {};
+
+        // Migrate regular stickers
+        console.log('Migrating regular stickers...');
+        for (const s of V1_STICKERS) {
+            const imageUrl = `${ASSETS_BASE_URL}/sticker${s.id}.png`;
+            let def = await StickerDefinition.findOne({ imageUrl });
+            
+            if (!def) {
+                def = await StickerDefinition.create({
+                    name: s.name,
+                    imageUrl,
+                    tags: ['legacy', 'regular'],
+                    metadata: { series: 'Legacy V1' }
+                });
+                console.log(`Created StickerDefinition for ${s.name}`);
+            }
+            stickerMap[s.id] = def._id;
+        }
+
+        // Migrate cheers stickers
+        console.log('Migrating cheers stickers...');
+        for (const c of V1_CHEERS) {
+            const imageUrl = `${ASSETS_BASE_URL}/c${c.id}.png`;
+            let def = await StickerDefinition.findOne({ imageUrl });
+
+            if (!def) {
+                def = await StickerDefinition.create({
+                    name: c.name,
+                    imageUrl,
+                    tags: ['legacy', 'cheers'],
+                    metadata: { series: 'Legacy Cheers V1' }
+                });
+                console.log(`Created StickerDefinition for ${c.name}`);
+            }
+            cheersMap[c.id] = def._id;
+        }
+
+        // Create legacy packs
+        console.log('Creating legacy packs...');
+        
+        const regularPackName = 'Legacy Starter Pack';
+        let regularPack = await StickerPack.findOne({ name: regularPackName });
+        if (!regularPack) {
+            regularPack = await StickerPack.create({
+                name: regularPackName,
+                packType: 'Basic',
+                stickers: Object.values(stickerMap)
+            });
+            console.log('Created Legacy Starter Pack');
+        }
+
+        const cheersPackName = 'Legacy Cheers Pack';
+        let cheersPack = await StickerPack.findOne({ name: cheersPackName });
+        if (!cheersPack) {
+            cheersPack = await StickerPack.create({
+                name: cheersPackName,
+                packType: 'Basic',
+                stickers: Object.values(cheersMap)
+            });
+            console.log('Created Legacy Cheers Pack');
+        }
+
+        console.log('Migration completed successfully');
+        process.exit();
+    } catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
+};
+
+migrate();
+


### PR DESCRIPTION
- Why: Current sticker assets are hard pathed by sequence number in the User and Stickerboard model collections. This limit does not support MVP scale or functionality.
- How: Added models: models/StickerDefinition.js defines the catalog of individual stickers including asset location and versioning, etc. models/StickerPack.js defines the relationships of individual stickers to the packs they can be organized into. scripts/stickerMigration.js pulls the extant legacy sticker entries from the database and populates the stickers and packs into the new format.
- Risks: This commit is scaffolding the database framework only and has not yet modified the deployed sticker functionality. We will incrementally build and test to ensure legacy collections and boards are not invalidated by new logic.