### PR TITLE
<feat>(stickers): User sticker palette moved to utilize recently-scaf…

### DIFF
--- a/client/src/components/stickerInterface/CanvasStage.jsx
+++ b/client/src/components/stickerInterface/CanvasStage.jsx
@@ -9,8 +9,13 @@ import useImage from "use-image";
  */
 const StickerSprite = React.memo(({ entry, boardSize, displayLongEdge, getStickerSrc, isValidStickerId }) => {
   const isValid = isValidStickerId(entry?.stickerId, entry?.isCheers);
-  const src = isValid ? getStickerSrc(entry.stickerId, entry?.isCheers) : null;
-  const [img] = useImage(src, 'anonymous');
+  const src = isValid ? getStickerSrc(entry.stickerId, entry?.isCheers, entry) : null;
+  const [img, status] = useImage(src, 'anonymous');
+
+  // Log only if src is expected but img is not loading
+  if (src && status === 'failed') {
+    console.warn(`StickerSprite failed to load image: ${src}`, entry);
+  }
 
   const scale = useMemo(() => {
     if (!isValid) return 1;
@@ -206,7 +211,6 @@ const CanvasStage = ({
     legacyStickerImage,
     legacyDefaultScale,
     currentPlacement,
-    placementStep,
   ]);
 
   return (

--- a/client/src/components/stickerInterface/StickerInterface.jsx
+++ b/client/src/components/stickerInterface/StickerInterface.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import useStickerCanvas from "../../hooks/useStickerCanvas";
+import useAuthStore from "../../store/authStore";
 import CanvasStage from "./CanvasStage";
 import StickerPalette from "./StickerPalette";
 import BoardSidebar from "./BoardSidebar";
@@ -9,6 +10,7 @@ import styles from "./StickerInterface.module.css";
 export default function StickerInterface(props) {
   const { readonly = false, forwardStageRef } = props;
   const stageRef = forwardStageRef || useRef(null);
+  const { user } = useAuthStore();
 
   const {
     bgImage,
@@ -84,13 +86,14 @@ export default function StickerInterface(props) {
       {!readonly && (
         <div className={styles.controls}>
           <StickerPalette
+            userId={user?._id || user?.id}
+            onStickerSelect={enterPlacementMode}
             isControlled={isControlled}
             internalStickers={internalStickers}
             isValidStickerId={isValidStickerId}
             isPlacing={isPlacing}
             placingIndex={placingIndex}
             getStickerSrc={getStickerSrc}
-            onSelectSticker={enterPlacementMode}
             isCheersMode={isCheersMode}
             cheersStickers={cheersStickers}
           />

--- a/client/src/components/stickerInterface/StickerInterface.module.css
+++ b/client/src/components/stickerInterface/StickerInterface.module.css
@@ -9,3 +9,103 @@
   flex-direction: column;
   gap: 16px;
 }
+
+.stickerPalette {
+  background: #f8f9fa;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #dee2e6;
+}
+
+.stickerGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.stickerIcon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: transform 0.2s, background-color 0.2s;
+  position: relative;
+  border: 2px solid transparent;
+}
+
+.stickerIcon:hover {
+  transform: translateY(-2px);
+  background-color: #e9ecef;
+}
+
+.available {
+  background-color: #fff;
+}
+
+.consumed {
+  opacity: 0.5;
+  filter: grayscale(1);
+}
+
+.stickerImage {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  margin-bottom: 4px;
+}
+
+.stickerName {
+  font-size: 12px;
+  text-align: center;
+  color: #495057;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.stickerCount {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: #007bff;
+  color: white;
+  border-radius: 10px;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-weight: bold;
+}
+
+.stickerPaletteTabs {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid #dee2e6;
+  padding-bottom: 8px;
+  overflow-x: auto;
+}
+
+.tabButton {
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid #dee2e6;
+  background: white;
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.tabButton.active {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.loading, .noStickers {
+  padding: 20px;
+  text-align: center;
+  color: #6c757d;
+  font-style: italic;
+}

--- a/client/src/components/stickerInterface/StickerPalette.test.jsx
+++ b/client/src/components/stickerInterface/StickerPalette.test.jsx
@@ -1,38 +1,107 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import StickerPalette from './StickerPalette';
+import { useStickerInventory } from '../../hooks/useStickerInventory';
+
+// Mock the hook
+vi.mock('../../hooks/useStickerInventory', () => ({
+  useStickerInventory: vi.fn()
+}));
+
+// Mock the CSS module
+vi.mock('./StickerInterface.module.css', () => ({
+  default: {
+    stickerPalette: 'stickerPalette',
+    stickerGrid: 'stickerGrid',
+    stickerIcon: 'stickerIcon',
+    available: 'available',
+    consumed: 'consumed',
+    stickerImage: 'stickerImage',
+    stickerName: 'stickerName',
+    stickerCount: 'stickerCount',
+    stickerPaletteTabs: 'stickerPaletteTabs',
+    tabButton: 'tabButton',
+    active: 'active',
+    loading: 'loading',
+    noStickers: 'noStickers'
+  }
+}));
 
 describe('StickerPalette', () => {
-  const mockOnSelectSticker = vi.fn();
-  const defaultProps = {
-    isControlled: true,
-    internalStickers: [
-      { stickerId: 1, stuck: false },
-      { stickerId: 2, stuck: true },
-    ],
-    isValidStickerId: (id) => id >= 0 && id <= 9,
-    isPlacing: false,
-    placingIndex: null,
-    getStickerSrc: (id) => `/sticker${id}.png`,
-    onSelectSticker: mockOnSelectSticker,
-  };
+  const mockFetchUserStickerInventory = vi.fn();
+  const mockAwardSticker = vi.fn();
+  const mockRevokeSticker = vi.fn();
 
-  it('should render available stickers in controlled mode', () => {
-    render(<StickerPalette {...defaultProps} />);
-    expect(screen.getByText(/sticker 1/i)).toBeInTheDocument();
-    expect(screen.queryByText(/sticker 2/i)).not.toBeInTheDocument(); // sticker 2 is stuck
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useStickerInventory.mockReturnValue({
+      fetchUserStickerInventory: mockFetchUserStickerInventory,
+      awardSticker: mockAwardSticker,
+      revokeSticker: mockRevokeSticker,
+      loading: false,
+      inventory: []
+    });
   });
 
-  it('should call onSelectSticker when a sticker is clicked', () => {
-    render(<StickerPalette {...defaultProps} />);
-    // Find button by its title or text content
-    fireEvent.click(screen.getByTitle(/click to place this sticker/i));
-    expect(mockOnSelectSticker).toHaveBeenCalledWith(0);
+  it('should show loading state initially', () => {
+    useStickerInventory.mockReturnValue({
+      fetchUserStickerInventory: mockFetchUserStickerInventory,
+      loading: true,
+      inventory: []
+    });
+    
+    render(<StickerPalette userId="user1" />);
+    expect(screen.getByText(/loading stickers.../i)).toBeInTheDocument();
   });
 
-  it('should render single sticker button in demo mode', () => {
-    render(<StickerPalette {...defaultProps} isControlled={false} />);
-    expect(screen.getByText(/sticker 0/i)).toBeInTheDocument();
+  it('should fetch inventory when userId is provided', async () => {
+    mockFetchUserStickerInventory.mockResolvedValue([]);
+    
+    render(<StickerPalette userId="user1" />);
+    
+    await waitFor(() => {
+      expect(mockFetchUserStickerInventory).toHaveBeenCalledWith('user1');
+    });
+  });
+
+  it('should render "No stickers available" when inventory is empty', async () => {
+    mockFetchUserStickerInventory.mockResolvedValue([]);
+    
+    render(<StickerPalette userId="user1" />);
+    
+    await waitFor(() => {
+      expect(screen.getByText(/no stickers available/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should call onStickerSelect when an available sticker is clicked', async () => {
+    const mockInventory = [
+      { id: 's1', name: 'Sticker 1', imageUrl: 'url1', packId: 'pack1', packName: 'Pack 1', quantity: 1 }
+    ];
+    mockFetchUserStickerInventory.mockResolvedValue(mockInventory);
+    const onStickerSelect = vi.fn();
+    
+    render(<StickerPalette userId="user1" onStickerSelect={onStickerSelect} />);
+    
+    const sticker = await screen.findByTitle('Sticker 1');
+    sticker.click();
+    
+    expect(onStickerSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 's1' }));
+  });
+
+  it('should not call onStickerSelect when a consumed sticker is clicked', async () => {
+    const mockInventory = [
+      { id: 's1', name: 'Sticker 1', imageUrl: 'url1', packId: 'pack1', packName: 'Pack 1', quantity: 0 }
+    ];
+    mockFetchUserStickerInventory.mockResolvedValue(mockInventory);
+    const onStickerSelect = vi.fn();
+    
+    render(<StickerPalette userId="user1" onStickerSelect={onStickerSelect} />);
+    
+    const sticker = await screen.findByTitle('Sticker 1');
+    sticker.click();
+    
+    expect(onStickerSelect).not.toHaveBeenCalled();
   });
 });

--- a/client/src/hooks/useStickerInventory.js
+++ b/client/src/hooks/useStickerInventory.js
@@ -1,0 +1,72 @@
+import { useState, useCallback } from 'react';
+
+export const useStickerInventory = () => {
+    const [inventory, setInventory] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    const fetchUserStickerInventory = useCallback(async (userId) => {
+        if (!userId) return [];
+        setLoading(true);
+        try {
+            const response = await fetch(`/api/v1/stickers/inventory/${userId}`);
+            const data = await response.json();
+            setInventory(data);
+            return data;
+        } catch (error) {
+            console.error('Failed to fetch sticker inventory:', error);
+            throw error;
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const awardSticker = useCallback(async (userId, stickerId, opId) => {
+        const response = await fetch(`/api/v1/stickers/award/${userId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                stickerId,
+                opId,
+                userId
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to award sticker');
+        }
+
+        const result = await response.json();
+        return result;
+    }, []);
+
+    const revokeSticker = useCallback(async (userId, stickerId, opId) => {
+        const response = await fetch(`/api/v1/stickers/revoke/${userId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                stickerId,
+                opId,
+                userId
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to revoke sticker');
+        }
+
+        const result = await response.json();
+        return result;
+    }, []);
+
+    return {
+        inventory,
+        fetchUserStickerInventory,
+        awardSticker,
+        revokeSticker,
+        loading
+    };
+};

--- a/controllers/stickerController.js
+++ b/controllers/stickerController.js
@@ -1,0 +1,145 @@
+const StickerInventory = require('../models/StickerInventory');
+const StickerDefinition = require('../models/StickerDefinition');
+const mongoose = require('mongoose');
+
+const createStickerTransaction = async (req, res, next) => {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+        const { userId, stickerId, opId } = req.body;
+
+        // Check if transaction already exists (idempotency)
+        const existingTransaction = await StickerInventory.findOne({
+            userId,
+            stickerId,
+            opId
+        });
+
+        if (existingTransaction) {
+            // Transaction already completed, return existing result
+            return res.json({
+                success: true,
+                message: 'Transaction already completed',
+                data: existingTransaction
+            });
+        }
+
+        // Check if user already has this sticker
+        const existingSticker = await StickerInventory.findOne({
+            userId,
+            stickerId
+        });
+
+        if (existingSticker) {
+            // Increment quantity
+            existingSticker.quantity += 1;
+            existingSticker.opId = opId; // Update opId for idempotency check if retried
+            // Ensure packId is set for existing entries that might be missing it
+            if (!existingSticker.packId) {
+                const stickerDef = await StickerDefinition.findById(stickerId);
+                if (stickerDef && stickerDef.packId) {
+                    existingSticker.packId = stickerDef.packId;
+                }
+            }
+            existingSticker.updatedAt = new Date();
+            await existingSticker.save({ session });
+            
+            await session.commitTransaction();
+            return res.json({
+                success: true,
+                message: 'Sticker quantity incremented',
+                data: existingSticker
+            });
+        }
+
+        // Fetch sticker definition to get packId
+        const stickerDef = await StickerDefinition.findById(stickerId);
+
+        // Create new sticker entry
+        const newStickerEntry = new StickerInventory({
+            userId,
+            stickerId,
+            packId: stickerDef ? stickerDef.packId : null,
+            opId,
+            quantity: 1,
+            timestamp: new Date()
+        });
+
+        await newStickerEntry.save({ session });
+
+        await session.commitTransaction();
+
+        res.json({
+            success: true,
+            message: 'Sticker awarded successfully',
+            data: newStickerEntry
+        });
+    } catch (error) {
+        await session.abortTransaction();
+        next(error);
+    } finally {
+        session.endSession();
+    }
+};
+
+const revokeStickerTransaction = async (req, res, next) => {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+        const { userId, stickerId, opId } = req.body;
+
+        // Check if transaction already exists (idempotency)
+        const existingTransaction = await StickerInventory.findOne({
+            userId,
+            stickerId,
+            opId
+        });
+
+        if (existingTransaction) {
+            // Transaction already completed, return existing result
+            return res.json({
+                success: true,
+                message: 'Transaction already completed',
+                data: existingTransaction
+            });
+        }
+
+        // Find and decrement the sticker entry quantity
+        const stickerEntry = await StickerInventory.findOne({
+            userId,
+            stickerId
+        });
+
+        if (!stickerEntry || stickerEntry.quantity <= 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'Sticker not available in user inventory'
+            });
+        }
+
+        stickerEntry.quantity -= 1;
+        stickerEntry.opId = opId;
+        stickerEntry.updatedAt = new Date();
+        await stickerEntry.save({ session });
+
+        await session.commitTransaction();
+
+        res.json({
+            success: true,
+            message: 'Sticker consumed successfully',
+            data: stickerEntry
+        });
+    } catch (error) {
+        await session.abortTransaction();
+        next(error);
+    } finally {
+        session.endSession();
+    }
+};
+
+module.exports = {
+    createStickerTransaction,
+    revokeStickerTransaction
+};

--- a/models/StickerInventory.js
+++ b/models/StickerInventory.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 
 const StickerInventorySchema = new mongoose.Schema({
     userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
-    stickerId: { type: mongoose.Schema.Types.ObjectId, ref: 'StickerDefinition', required: true },
+    stickerId: { type: mongoose.Schema.Types.ObjectId, ref: 'StickerDefinition'},
+    packId: { type: mongoose.Schema.Types.ObjectId, ref: 'StickerPack'},
     quantity: { type: Number, default: 0, required: true, min: 0 },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },

--- a/models/Stickerboard.js
+++ b/models/Stickerboard.js
@@ -46,7 +46,9 @@ const StickerboardSchema = new mongoose.Schema({
     height: Number,            // logical height (e.g. 700)
     stickers: [
         {
-            stickerId: { type: Number, required: true, min: 0, max: 10000 },     // predefined asset id
+            stickerId: { type: mongoose.Schema.Types.Mixed, required: true },     // supports both Number (legacy) and ObjectId (new)
+            imageUrl: String,                                                     // Persisted URL for inventory stickers
+            name: String,                                                         // Persisted name
             x: { type: Number, required: true, min: -5000, max: 5000 },             // normalized or absolute coordinates
             y: { type: Number, required: true, min: -5000, max: 5000 },
             scale: { type: Number, default: 1, min: 0.0001, max: 10 },

--- a/routes/stickers.js
+++ b/routes/stickers.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const router = express.Router();
+const { createStickerTransaction, revokeStickerTransaction } = require('../controllers/stickerController');
+const StickerInventory = require('../models/StickerInventory');
+
+// Award sticker to user (idempotent)
+router.post('/award/:userId', createStickerTransaction);
+
+// Revoke sticker from user (idempotent)
+router.post('/revoke/:userId', revokeStickerTransaction);
+
+// Get user's sticker inventory
+router.get('/inventory/:userId', async (req, res) => {
+    try {
+        const { userId } = req.params;
+        const inventory = await StickerInventory.find({ userId })
+            .populate({
+                path: 'stickerId',
+                populate: {
+                    path: 'packId',
+                    model: 'StickerPack'
+                }
+            })
+            .populate('packId');
+        
+        // Transform to include sticker details at the top level for the frontend
+        const transformedInventory = inventory.map(item => {
+            if (!item.stickerId) return null;
+            
+            // Priority: packId from inventory item (populated), or from sticker definition
+            const pack = item.packId || item.stickerId.packId;
+            const packId = pack ? (pack._id || pack) : 'default';
+            const packName = pack ? pack.name : 'Assorted';
+
+            return {
+                id: item.stickerId._id,
+                name: item.stickerId.name,
+                imageUrl: item.stickerId.imageUrl,
+                packId: packId,
+                packName: packName,
+                inventoryId: item._id,
+                quantity: item.quantity
+            };
+        }).filter(item => item !== null);
+
+        res.json(transformedInventory);
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -42,6 +42,7 @@ const auth = require('./routes/auth');
 const users = require('./routes/users');
 const comments = require('./routes/comments');
 const admin = require('./routes/admin');
+const stickers = require('./routes/stickers');
 
 // define express app
 const app = express();
@@ -150,6 +151,7 @@ app.use('/api/v1/auth', auth);
 app.use('/api/v1/auth/users', users);
 app.use('/api/v1/comments', comments)
 app.use('/api/v1/admin', admin);
+app.use('/api/v1/stickers', stickers);
 
 
 

--- a/test/__tests__/stickerboard.invariants.test.js
+++ b/test/__tests__/stickerboard.invariants.test.js
@@ -152,7 +152,7 @@ describe('Stickerboard invariants', () => {
       .expect(400);
 
     // Assertions
-    expect(res.body.error).toMatch(/User does not have the required Cheers! sticker/i);
+    expect(res.body.error).toMatch(/User does not have the required sticker/i);
 
     // Board unchanged
     const board = await Stickerboard.findById(boardId);


### PR DESCRIPTION
…folded sticker catalog and inventory documents.

Why: The original implementation of sticker inventories was hard coded to asset file names as array entries in the stickerboard document and the user document. The current system now maintains a catalog of StickerDefinitions and StickerPacks defining stickers and sets of stickers, as well as a StickerInventory with is a document containing the relationship of every awarded/owned sticker in the economy to its owning user. The front-end sticker palette had not yet been refactored to utilize this new system.
What: StickerPalette.jsx component now pulls from the StickerInventory all records matching the user (stickers and packs) and organizes them into tabbed icon lists for placing on boards, organized by packs. Stickers which have been stuck are greyed out and inaccessible.
How Verified: database snooping and updated test suite to validate the already-implemented idempotent transactions through operationslog when placing stickers from the new sticker palette.
Risks/Notes: The pace of iteration on the sticker set project has been rapid, and new assets have not yet been ingested into the database for full sets. The component structure is getting complicated, the database documents have expanded, and there are now additional routes and controllers necessary to make all this work.